### PR TITLE
Safely access metadata

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -47,7 +47,8 @@ class YoutubeDLAgent(Agent.TV_Shows):
 
                         metadata.title = data['uploader']
                         metadata.studio = data['uploader']
-                        metadata.summary = data['playlist_title']
+                        if 'playlist_title' in data:
+                            metadata.summary = data['playlist_title']
 
                         break
                 except IOError:
@@ -89,13 +90,13 @@ class YoutubeDLAgent(Agent.TV_Shows):
                             episode.title = data['fulltitle']
                             episode.summary = data["description"]
 
-                            if data['playlist_index']:
+                            if 'playlist_index' in data:
                                 episode.absolute_index = data['playlist_index']
 
-                            if data['upload_date']:
+                            if 'upload_date' in data:
                                 episode.originally_available_at = Datetime.ParseDate(data['upload_date']).date()
 
-                            if data['average_rating']:
+                            if 'average_rating' in data:
                                 episode.rating = (data['average_rating'] * 2)
 
                             Log("Processed successfully! This episode was named '{}'".format(data['fulltitle']))


### PR DESCRIPTION
When a key is missing from info.json, it shouldn't prevent the rest of
the data from being loaded.

When adding an item that wasn't a part of a playlist, there will be no
'playlist_title'. Before this change, all the metadata would be missing
from these videos. Now, the other data gets loaded. Yay!

I tried to replecate the pattern already established of using:

```
if data['key']:
```

but this raised the same KeyError when the key didn't exist. I'm not a
regular Python dev but I think something changed in Python 3. Using the
`in` syntax here seems to work great for all the places I changed.

I think this should address:

https://github.com/JordyAlkema/Youtube-DL-Agent.bundle/issues/6#issuecomment-912676366
https://github.com/JordyAlkema/Youtube-DL-Agent.bundle/issues/10#issuecomment-961840829
https://github.com/JordyAlkema/Youtube-DL-Agent.bundle/issues/12

As the issue they describe has the same symptoms that I was
experiencing.