### PR TITLE
Support local media (subtitles, channel profile pic)

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -10,7 +10,7 @@ def Start():
 
 class YoutubeDLAgent(Agent.TV_Shows):
     name, primary_provider, fallback_agent, contributes_to, languages, accepts_from = (
-    'Youtube-DL', True, False, None, [Locale.Language.English, ], None)
+    'Youtube-DL', True, None, None, [Locale.Language.English, ], ['com.plexapp.agents.localmedia'])
 
     def search(self, results, media, lang, manual=False):
         results.Append(MetadataSearchResult(

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Fork notice
+
+This fork enables local media assets, such as `poster.jpg` for channel posters, and subtitles.
+
 # Youtube-DL Agent
 After about a year of using [ZeroQI's Youtube Agent](https://github.com/ZeroQI/YouTube-Agent.bundle) I noticed a problem. If a youtube video gets deleted, it is no longer possible to get the metadata. Which makes sense, however the entire goal of having Youtube videos on your Plex Media Server is to make sure they never get deleted. 
 


### PR DESCRIPTION
Make it able to load extra local assets supported by Plex.

For example:
- Now it can load subtitles (#11)
- Load channel profile photos (add `show.jpg` in your channel folder) (#10, #16)
- Banner images
- Theme song
- Fix #20 